### PR TITLE
fix keymap & make package usable

### DIFF
--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -173,14 +173,18 @@ Centering is done pixel wise relative to window width.")
   (org-view-mode -1)
   (message "org-view mode disabled in current buffer"))
 
-(defvar-keymap org-view-mode-map
-  :doc "Keymap for ‘ORG-view-mode’"
-  "c" #'org-view-quit
-  "C" #'org-view-quit
-  "e" #'org-view-quit
-  "E" #'org-view-quit
-  "q" #'org-view-quit
-  "Q" #'org-view-quit)
+;; (defvar org-view-mode-map
+;;   :doc "Keymap for ‘ORG-view-mode’"
+;;   "c" #'org-view-quit
+;;   "C" #'org-view-quit
+;;   "e" #'org-view-quit
+;;   "E" #'org-view-quit
+;;   "q" #'org-view-quit
+;;  "Q" #'org-view-quit)
+(defvar org-view-mode-map (let ((map (make-sparse-keymap)))
+                            (define-key map (kbd "q") 'org-view-quit)
+                            map)
+  "The keymap for org-view-mode")
 
 ;;;###autoload
 (define-minor-mode org-view-mode

--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -115,7 +115,7 @@ Centering is done pixel wise relative to window width.")
   (org-with-wide-buffer
    (save-excursion
      (with-silent-modifications
-       (goto-char (point-min))         
+       (goto-char (point-min))
        (while (re-search-forward org-view-credentials-re nil t)
          (put-text-property
           (match-beginning 0) (match-end 0) 'invisible visibility)

--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -195,13 +195,13 @@ Centering is done pixel wise relative to window width.")
   (cond (org-view-mode
          (org-view-hide-tags-mode org-view-mode)
          (org-view-hide-stars-mode org-view-mode)
-         (org-view-hide-keywords-mode org-view-mode)
+;;         (org-view-hide-keywords-mode org-view-mode)
          (org-view-hide-properties-mode org-view-mode)
          (org-view-pretty-credentials-mode org-view-mode)
          (when org-view-diminish-mode
            (dolist (mode '(org-view-hide-tags-mode
                            org-view-hide-stars-mode
-                           org-view-hide-keywords-mode
+;;                           org-view-hide-keywords-mode
                            org-view-hide-properties-mode
                            org-view-pretty-credentials-mode))
              (let ((mode-str (cdr (assq mode minor-mode-alist))))
@@ -210,7 +210,7 @@ Centering is done pixel wise relative to window width.")
         (t (view-mode -1)
            (org-view-hide-tags-mode -1)
            (org-view-hide-stars-mode -1)
-           (org-view-hide-keywords-mode -1)
+;;           (org-view-hide-keywords-mode -1)
            (org-view-hide-properties-mode -1)
            (org-view-pretty-credentials-mode -1))))
 


### PR DESCRIPTION
I was unable to get this package working as-is while following the directions, so I spent a couple minutes debugging `main`.

- https://github.com/amno1/org-view-mode/commit/803b2690d7e99a3b6888df9862d413f5e71949ba#diff-af1203a6fff89e504352264af9df62ded956d9de93b6192a5187068f7dd19a85L176 This keymap was throwing a type error that prevented the package from loading, so I commented it out and refactored it. I only added `q` for quitting org-view-mode.
- Undefined function `org-view-hide-keywords-mode` was preventing me from being able to load the package.

I've tested it on my end after these changes and `org-view-mode` is now working.