### PR TITLE
Package manager docs

### DIFF
--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -115,7 +115,7 @@ Centering is done pixel wise relative to window width.")
   (org-with-wide-buffer
    (save-excursion
      (with-silent-modifications
-       (goto-char (point-min))         
+       (goto-char (point-min))
        (while (re-search-forward org-view-credentials-re nil t)
          (put-text-property
           (match-beginning 0) (match-end 0) 'invisible visibility)

--- a/readme.org
+++ b/readme.org
@@ -14,15 +14,27 @@
   [[./screencast.gif]]
   
 * Installation  
+** Straight
+You may use straight.el to install this package, or some combination of straight & use-package
+#+begin_src emacs-lisp
+;; straight.el
+(straight-use-package
+  '(org-view-mode :type git :host github :repo "amno1/org-view-mode"))
 
-  Either clone this repo or just download 'org-view-mode.el'.
+;; use-package & straight
+(use-package org-view-mode
+  :straight (org-view-mode :type git :host github :repo "amno1/org-view-mode"))
+#+end_src
 
-  Put org-view-mode.el somewhere in Emacs load-path. From there you
-  can either:
+** Manual
+Either clone this repo or just download 'org-view-mode.el'.
 
-  M-x package-install-file RET org-view-mode.el RET
+Put org-view-mode.el somewhere in Emacs load-path. From there you
+can either:
 
-  or just require file in your init file somewhere.
+M-x package-install-file RET org-view-mode.el RET
+
+or just require file in your init file somewhere.
 
 * Requirements
 


### PR DESCRIPTION
Added some documentation for how to install this package using `use-package` provided that `straight.el` is in use. This will help people package manage `org-view-mode` until you maybe end up on elpa :)