### PR TITLE
Fix compatibility with future font-lock-ensure function

### DIFF
--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -210,17 +210,20 @@ Centering is done pixel wise relative to window width."
 (defun org-view--on ()
   "Properly enter `org-view-mode'."
   (add-hook 'change-major-mode-hook #'org-view--off nil t)
-    (setq org-view--old-read-only buffer-read-only
-          buffer-read-only t)
-    (when org-view-hide-ellipses
-      (unless buffer-display-table
-        (setq buffer-display-table standard-display-table))
-      (setq org-view--old-ellipses
-            (display-table-slot buffer-display-table 'selective-display))
-      (set-display-table-slot buffer-display-table
-                              'selective-display (string-to-vector "")))
-    (org-font-lock-ensure 1 (point-max))
-    (org-view--toggle-features t))
+  (setq org-view--old-read-only buffer-read-only
+        buffer-read-only t)
+  (when org-view-hide-ellipses
+    (unless buffer-display-table
+      (setq buffer-display-table standard-display-table))
+    (setq org-view--old-ellipses
+          (display-table-slot buffer-display-table 'selective-display))
+    (set-display-table-slot buffer-display-table
+                            'selective-display (string-to-vector "")))
+  (apply (cond ((functionp 'org-font-lock-ensure) 'org-font-lock-ensure)
+               ((functionp 'font-lock-ensure) 'font-lock-ensure)
+               (t (lambda (_) (error "No font-lock-ensure function"))))
+         `(1 ,(point-max)))
+  (org-view--toggle-features t))
 
 (defun org-view--off ()
   "Properly exit `org-view-mode'."

--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -221,7 +221,7 @@ Centering is done pixel wise relative to window width."
                             'selective-display (string-to-vector "")))
   (apply (cond ((functionp 'org-font-lock-ensure) 'org-font-lock-ensure)
                ((functionp 'font-lock-ensure) 'font-lock-ensure)
-               (t (lambda (_) (error "No font-lock-ensure function"))))
+               (t (lambda (&rest _) (error "No font-lock-ensure function"))))
          `(1 ,(point-max)))
   (org-view--toggle-features t))
 

--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -219,10 +219,7 @@ Centering is done pixel wise relative to window width."
           (display-table-slot buffer-display-table 'selective-display))
     (set-display-table-slot buffer-display-table
                             'selective-display (string-to-vector "")))
-  (apply (cond ((functionp 'org-font-lock-ensure) 'org-font-lock-ensure)
-               ((functionp 'font-lock-ensure) 'font-lock-ensure)
-               (t (lambda (&rest _) (error "No font-lock-ensure function"))))
-         `(1 ,(point-max)))
+  (font-lock-ensure 1 (point-max))
   (org-view--toggle-features t))
 
 (defun org-view--off ()


### PR DESCRIPTION
Fixes https://github.com/amno1/org-view-mode/issues/11

Adds a conditional to check for and use the relevant `font-lock-ensure` function.  Throws a descriptive error if neither expected function exists.