### PR TITLE
Add org-view-font feature

### DIFF
--- a/org-view-font.el
+++ b/org-view-font.el
@@ -25,6 +25,10 @@
 (require 'face-remap)
 (require 'cl-seq)
 
+(defgroup 'org-view-font nil
+  "Special font customizations for `org-view-mode'."
+  :group 'org-view)
+
 ;;;###autoload
 (defcustom org-view-font-remaps
   '((default . (:family "Serif" :height 1.25))

--- a/org-view-font.el
+++ b/org-view-font.el
@@ -25,7 +25,7 @@
 (require 'face-remap)
 (require 'cl-seq)
 
-(defgroup 'org-view-font nil
+(defgroup org-view-font nil
   "Special font customizations for `org-view-mode'."
   :group 'org-view)
 

--- a/org-view-font.el
+++ b/org-view-font.el
@@ -1,0 +1,121 @@
+;;; org-view-font.el --- Font switcher module for org-view-mode -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Trevor Richards
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file is a library that contains the necessary code for `org-view-mode'
+;; to be able to toggle a "reading font" off and on.
+
+
+;;; Code:
+(require 'face-remap)
+(require 'cl-seq)
+
+;;;###autoload
+(defcustom org-view-font-remaps
+  '((default . (:family "Serif" :height 1.25))
+    (org-document-title . (:height 1.2))
+    (org-level-1 . (:height 1.4 :weight normal))
+    (org-level-2 . (:height 1.3 :weight normal))
+    (org-level-3 . (:height 1.2 :weight normal))
+    (org-level-4 . (:height 1.1 :slant italic))
+    (org-level-5 . (:height 1.0 :weight semibold))
+    (org-level-6 . (:height 1.0 :weight semibold))
+    (org-level-7 . (:height 1.0 :weight semibold))
+    (org-level-8 . (:height 1.0 :weight semibold))
+    (org-link . (:underline t :weight normal)))
+  "Faces to remap, with attributes to remap."
+  :type '(alist :key-type face
+                :value-type (plist :key-type symbol
+                                   :value-type sexp))
+  :group 'org-view-font)
+
+;;;###autoload
+(defcustom org-view-font-no-remap
+  '(org-block
+    org-block-begin-line
+    org-block-end-line
+    org-document-info-keyword
+    org-code
+    org-latex-and-related
+    org-checkbox
+    org-meta-line
+    org-table
+    org-drawer
+    org-special-keyword
+    org-property-value
+    org-verbatim)
+  "Faces to avoid remapping."
+  :type '(repeat face)
+  :group 'org-view-font)
+
+;;;###autoload
+(defcustom org-view-font-enable nil
+  "Enable the custom reading font settings for `org-view-mode'."
+  :type 'boolean
+  :group 'org-view-font)
+
+
+
+(defvar org-view-font--cookies '()
+  "A record of remapped faces used by `org-view-mode'.")
+
+(defun org-view-font--apply-remap (setting)
+  "Invoke `face-remap-add-relative' with a given face `SETTING'."
+  (face-remap-add-relative (car setting) (cdr setting)))
+
+(defun org-view-font--remap-faces (remaps)
+  "Apply `REMAPS' and store a record of them in the cookie storage."
+  (dolist (cookie (cl-mapcar 'org-view-font--apply-remap (reverse remaps)))
+    (add-to-list 'org-view-font--cookies cookie)))
+
+(defun org-view-font--to-face-props (face)
+  "Reduce a `FACE' into a property list of its face properties."
+  (cl-reduce
+   `(lambda (props name)
+      (plist-put props (car name) (face-attribute ',face (car name))))
+   face-attribute-name-alist
+   :initial-value '()))
+
+(defun org-view-font--default-setting (face)
+  "Create a default setting for a `FACE'.  Preserves pre-existing settings."
+  (let ((props (org-view-font--to-face-props face)))
+    (cons face (plist-put props :family (face-attribute 'default :family)))))
+
+(defun org-view-font--clear-remaps (cookies)
+  "Clear the remaps in a `COOKIES' list."
+  (dolist (c cookies)
+    (face-remap-remove-relative c)))
+
+
+
+;;;###autoload
+(defun org-view-font-enable-font ()
+  "Enable the org-view-font feature."
+  (org-view-font--remap-faces org-view-font-remaps)
+  (org-view-font--remap-faces (cl-mapcar 'org-view-font--default-setting
+                                         org-view-font-no-remap)))
+
+;;;###autoload
+(defun org-view-font-disable-font ()
+  "Disable the org-view-font feature."
+  (org-view-font--clear-remaps org-view-font--cookies)
+  (setq org-view-font--cookies '()))
+
+(provide 'org-view-font)
+
+;;; org-view-font.el ends here

--- a/org-view-mode.el
+++ b/org-view-mode.el
@@ -38,6 +38,7 @@
 
 ;;; Code:
 (require 'org)
+(require 'org-view-font)
 
 ;;; Options
 (defgroup org-view nil
@@ -205,7 +206,9 @@ Centering is done pixel wise relative to window width."
   (if org-view-prettify-paragraphs
       (org-view--update-paragraphs on))
   (if org-view-prettify-credentials
-      (org-view--update-credentials on)))
+      (org-view--update-credentials on))
+  (if org-view-font-enable
+      (org-view--update-view-font on)))
 
 (defun org-view--on ()
   "Properly enter `org-view-mode'."
@@ -327,6 +330,12 @@ Centering is done pixel wise relative to window width."
                 (match-beginning 0) (match-end 0) 'invisible visibility))
              (org-view--center-region left right width visibility)))
            (forward-line))))))
+
+(defun org-view--update-view-font (enable)
+  "Turn on specialized font settings if `ENABLE' is non-nil."
+  (if enable
+      (org-view-font-enable-font)
+    (org-view-font-disable-font)))
 
 (defun org-view--fill-column-pixel-width ()
   "Return width for `fill-column' in pixels.

--- a/readme.org
+++ b/readme.org
@@ -170,6 +170,28 @@ For other options avialable please see the org-view group in customize:
 
 M-x customize-group RET org-view
 
+** Org View Font
+
+Org view mode comes with an optional =org-view-font= feature.  This gives you the
+ability to use a variable pitch/alternate font for reading org documents.
+
+You may utilize it by customizing the following variables:
+
+- =org-view-font-enable= to enable/disable the =org-view-font= feature
+- =org-view-font-remaps= (alist) to add/remove explicit face settings for org-mode
+- =org-view-font-no-remap= (list) to protect specific faces from being remapped
+
+Use =M-x customize-group org-view-font= to view these customization options in one
+view.
+
+You may also customize the view font with elisp:
+
+#+begin_src elisp
+(require 'org-view-mode)
+(setq org-view-font-enable)
+(add-to-list 'org-view-font-remaps '(default . (:family "Noto Sans")))
+#+end_src
+
 * Issues
 
 There might be lots of issues I am not aware of, since I haven't extensively


### PR DESCRIPTION
Ref: https://github.com/amno1/org-view-mode/issues/3

This PR adds a new feature: **org-view-font**.

As requested, the feature is written in a separate module that is imported by the `org-view-mode.el` module.  Special thanks to @andersjohansson for sharing their implementation.  I have more-or-less implemented a simplified version of their doc-font module.

The general idea is that the end user can customize `org-view-font-enable` and `org-view-font-remaps` to customize their own bespoke "reading font" for an alist of faces, starting with the `default` face. 

If they would like certain faces left alone, they may add it to the `org-view-font-no-remap` list.

Documentation is provided in this pull request.

Obligatory gif, uses the "Carlito" font family:
![org-view-demo](https://user-images.githubusercontent.com/28788713/205427166-a778687b-3e2e-49fc-afa2-2a1613432c7b.gif)
